### PR TITLE
httl template class may not found

### DIFF
--- a/httl/src/main/java/httl/spi/compilers/JdkCompiler.java
+++ b/httl/src/main/java/httl/spi/compilers/JdkCompiler.java
@@ -228,7 +228,7 @@ public class JdkCompiler extends AbstractCompiler {
             try {
                 return super.findClass(qualifiedClassName);
             } catch (ClassNotFoundException e) {
-                byte[] bytes = jfo.getByteCode();
+                byte[] bytes = qname2Loader.get(stripClassTimestamp(qualifiedClassName)).jfo.getByteCode();
                 try {
                     saveBytecode(qualifiedClassName, bytes);
                 } catch (IOException e2) {


### PR DESCRIPTION
this bug can be easily tested : 
```
		Engine engine1 = Engine.getEngine();
		Template template = engine1.getTemplate("/books.httl");
```
```
books.httl
<!--#macro(main)-->
    <table>
        <!--#for(httl.script.Book book : books)-->
        <tr>
            <td>${book.title}</td>
        </tr>
        <!--#end-->
    </table>
<!--#end-->
```